### PR TITLE
TouchProcessInfo: use shell execute like .NET Framework's default

### DIFF
--- a/Gu.Wpf.NumericInput/Touch/TouchProcessInfo.cs
+++ b/Gu.Wpf.NumericInput/Touch/TouchProcessInfo.cs
@@ -8,7 +8,7 @@ namespace Gu.Wpf.NumericInput.Touch
     {
         private TouchProcessInfo(string path)
         {
-            this.ProcessStartInfo = new ProcessStartInfo(path);
+            this.ProcessStartInfo = new ProcessStartInfo(path) { UseShellExecute = true };
             this.ProcessName = Path.GetFileNameWithoutExtension(path);
         }
 


### PR DESCRIPTION
The default in .NET Framework and newer .NET (or .NET Core) changed. However, when "UseShellExecute" set to false (in newer .NET), starting the process fails immediately and stops the application.

This is enough for an application in .NET 8 to not crash when using a touchscreen with the property `touch:TextBox.ShowTouchKeyboardOnTouchEnter="True"` set for a text box/NumericBox, on Windows 11 23H2.

However, it is not enough for the functionality to work as before. After reading a bit, it seems that since at least some Windows 10 release, the current workarounds doesn't work anymore. You might want to take a look at https://github.com/AlexeiScherbakov/osklib or https://github.com/Seuleuzeuh/WPFTabTipMixedhardware that seemed to have a more complete handling of TabTip that doesn't open in recent versions of Win10 and Win11.


To avoid having future crashes in the future, and to have to create a custom build of this library with the Touch functionality removed like I had to, I would suggest having the namespace "Gu.Wpf.NumericInput.Touch" published as a separate nuget package.

